### PR TITLE
feat: add env var to configure optional context root

### DIFF
--- a/requestbin/config.py
+++ b/requestbin/config.py
@@ -28,6 +28,8 @@ REDIS_PREFIX = "requestbin"
 
 BUGSNAG_KEY = ""
 
+CONTEXT_ROOT = os.environ.get('CONTEXT_ROOT', '/')
+
 if REALM == 'prod':
     DEBUG = False
     ROOT_URL = "http://requestb.in"

--- a/requestbin/templates/layout.html
+++ b/requestbin/templates/layout.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>{% block title %}RequestBin &mdash; Collect, inspect and debug HTTP requests and webhooks{% endblock %}</title>
+    <base href="{{base_path}}" />
     {% block icon %}<link href="/static/img/logo.png" rel="shortcut icon" />{% endblock %}
     <link href="/static/css/bootstrap.css" rel="stylesheet" media="screen">
     <link href="/static/css/responsive.css" rel="stylesheet" media="screen">

--- a/requestbin/views.py
+++ b/requestbin/views.py
@@ -1,7 +1,7 @@
 import urllib
 from flask import session, redirect, url_for, escape, request, render_template, make_response
 
-from requestbin import app, db
+from requestbin import app, config, db
 
 def update_recent_bins(name):
     if 'recent' not in session:
@@ -31,7 +31,8 @@ def home():
     return render_template (
                 'home.html', 
                 recent=expand_recent_bins(),
-                base_url=request.scheme+'://'+request.host
+                base_url=request.scheme+'://'+request.host+config.CONTEXT_ROOT,
+                base_path=config.CONTEXT_ROOT
            )
 
 
@@ -48,7 +49,9 @@ def bin(name):
         update_recent_bins(name)
         return render_template('bin.html',
             bin=bin,
-            base_url=request.scheme+'://'+request.host)
+            base_url=request.scheme+'://'+request.host+config.CONTEXT_ROOT,
+                base_path=config.CONTEXT_ROOT
+        )
     else:
         db.create_request(bin, request)
         resp = make_response("ok\n")
@@ -63,6 +66,7 @@ def docs(name):
         return render_template('doc.html',
                 content=doc['content'],
                 title=doc['title'],
-                recent=expand_recent_bins())
+                recent=expand_recent_bins(),
+                base_path=config.CONTEXT_ROOT)
     else:
         return "Not found", 404


### PR DESCRIPTION
This PR introduced a environment variable to define a context root. With this, request bin can be hosted behind a proxy using context roots for routing.

Without this, request bin is not able to render the HTML, as all requests to load CSS, JS, icons, etc. are sent to the server without using the context root.